### PR TITLE
Initialization of local variables in _atodt and _web_b2s_enum_multi

### DIFF
--- a/Lib/Rabbit4000/RabbitWeb/RWEB_GENERIC.LIB
+++ b/Lib/Rabbit4000/RabbitWeb/RWEB_GENERIC.LIB
@@ -2036,8 +2036,8 @@ int _web_b2s_enum_multi(WebCursor_t __far * wc, char __far * str, int maxlen, co
 	   }
 	}
 	else {
+		i32 = bin ? *(unsigned long __far *)bin : 0uL;
 		for (m32 = 1; m32; m32 <<= 1) if (i32 & m32) {
-	      i32 = bin ? *(unsigned long __far *)bin : 0uL;
 	      for (p32 = meta->select.ptr32; p32->name; ++p32)
 	         if (p32->value == i32)
 	            break;

--- a/Lib/Rabbit4000/STDIO.LIB
+++ b/Lib/Rabbit4000/STDIO.LIB
@@ -2329,7 +2329,7 @@ int _atodt(const char __far*str) {
 	auto int date;
 	auto char __far*tail;
 	auto int i;
-	auto struct tm t;
+	auto struct tm t = {0, 0, 0};
 
 	static const int __dom[2][12] =
 		{


### PR DESCRIPTION
In my opinion `struct t` in `_atodt` must be initialized before use, see also: http://www.digi.com/support/forum/35652/stdio-lib-library-bug-report-_atodt-giving-strange-results

Besides, i think `i32` isn't properly initialized in `_web_b2s_enum_multi`. It should be initialized (like `i16`) before the `for` loop: http://www.digi.com/support/forum/37532/bug-in-rweb_generic-lib-function-_web_b2s_enum_multi
