### PR TITLE
Initialize struct t in _atodt before use.

### DIFF
--- a/Lib/Rabbit4000/STDIO.LIB
+++ b/Lib/Rabbit4000/STDIO.LIB
@@ -2329,7 +2329,7 @@ int _atodt(const char __far*str) {
 	auto int date;
 	auto char __far*tail;
 	auto int i;
-	auto struct tm t;
+	auto struct tm t = { 0 };
 
 	static const int __dom[2][12] =
 		{


### PR DESCRIPTION
Uninitialized struct tm t may give random results, see also: http://www.digi.com/support/forum/35652/stdio-lib-library-bug-report-_atodt-giving-strange-results
