### PR TITLE
Fixing a trivial bug in _web_b2s_enum_multi.

### DIFF
--- a/Lib/Rabbit4000/RabbitWeb/RWEB_GENERIC.LIB
+++ b/Lib/Rabbit4000/RabbitWeb/RWEB_GENERIC.LIB
@@ -2036,8 +2036,8 @@ int _web_b2s_enum_multi(WebCursor_t __far * wc, char __far * str, int maxlen, co
 	   }
 	}
 	else {
+		i32 = bin ? *(unsigned long __far *)bin : 0uL;
 		for (m32 = 1; m32; m32 <<= 1) if (i32 & m32) {
-	      i32 = bin ? *(unsigned long __far *)bin : 0uL;
 	      for (p32 = meta->select.ptr32; p32->name; ++p32)
 	         if (p32->value == i32)
 	            break;


### PR DESCRIPTION
The i32 local variable must be initialized (like i16) before the for loop, see also: http://www.digi.com/support/forum/37532/bug-in-rweb_generic-lib-function-_web_b2s_enum_multi
