### PR TITLE
Ssl code size reductions 1

### DIFF
--- a/Lib/Rabbit4000/Crypto/SHA2.LIB
+++ b/Lib/Rabbit4000/Crypto/SHA2.LIB
@@ -54,10 +54,10 @@ typedef struct
 {
 	// length of all input data added
 	uint32_t total[2];
-	
+
 	// current state of the hash
 	uint32_t state[8];
-	
+
 	// buffer of unprocessed bytes; algorithm requires a full block of 64 bytes
 	uint8_t buffer[64];
 } sha256_context;
@@ -162,7 +162,7 @@ uint32_t _sha256_F0_S2(uint32_t _x, uint32_t _y, uint32_t _z)
 		rlc 1, bcde     ; BCDE = ROTR(x,13) (same as ROTL(x,19))
 		xor jkhl, bcde  ; JKHL = ROTR(x,2) ^ ROTR(x,22) ^ ROTR(x,13)
 		ld pw, jkhl     ; PW = S2(x)
-		
+
 		ld bcde, px
 		ld py, (sp+@SP+_y)
 		ld jkhl, py
@@ -174,7 +174,7 @@ uint32_t _sha256_F0_S2(uint32_t _x, uint32_t _y, uint32_t _z)
 		and jkhl, bcde        ; jkhl = z & (x + y)
 		ld bcde, pz
 		or jkhl, bcde         ; jkhl = (x & y) | (z & (x | y))
-		
+
 		ld bcde, pw
 		add jkhl, bcde        ; add S2(x) before returning
 		ex jkhl, bcde
@@ -198,7 +198,7 @@ uint32_t _sha256_F1_S3(uint32_t _x, uint32_t _y, uint32_t _z)
 		rrc 1, bcde     ; bcde = ROTR(x,11)
 		xor jkhl, bcde  ; jkhl = ROTR(x,25) ^ ROTR(x,6) ^ ROTR(x,11)
 		ld pw, jkhl     ; pw = S3(x)
-		
+
 		ld bcde, (sp+@SP+_z)
 		ld pz, bcde
 		ld jkhl, (sp+@SP+_y)
@@ -207,7 +207,7 @@ uint32_t _sha256_F1_S3(uint32_t _x, uint32_t _y, uint32_t _z)
 		and jkhl, bcde           ; jkhl = x & (y ^ z)
 		ld bcde, pz
 		xor jkhl, bcde           ; jkhl = z ^ (x & (y ^ z))
-		
+
 		ld bcde, pw
 		add jkhl, bcde           ; jkhl = S3(x) + (z ^ (x & (y ^ z)))
 		ex jkhl, bcde
@@ -261,15 +261,14 @@ END DESCRIPTION **********************************************************/
 _sha2_debug
 void sha256_process(sha256_context __far *ctx, const uint8_t __far data[64])
 {
-	uint32_t temp1, temp2, W[64];
+	uint32_t W[64], temp1;
 	// note that code later in this function relies on A-H being
 	// sequential on the stack, starting with A
 	uint32_t H, G, F, E, D, C, B, A;
 	uint32_t __far *state, *work;
 	int i;
-
 	sha_copy_and_swap(W, data, 16);
-	
+
 #define R(t)   (W[t] = S1(W[t - 2]) + S0(W[t - 15]) + W[t - 7] + W[t - 16])
 #define P(a,b,c,d,e,f,g,h,x,K)                  \
 {                                               \
@@ -279,7 +278,8 @@ void sha256_process(sha256_context __far *ctx, const uint8_t __far data[64])
 }
 
 	// copy ctx->state[0..7] to A..H
-	_f_memcpy(&A, ctx->state, 32);
+	state = ctx->state;
+	_f_memcpy(&A, state, 32);
 
 	P( A, B, C, D, E, F, G, H, W[ 0], 0x428A2F98 );
 	P( H, A, B, C, D, E, F, G, W[ 1], 0x71374491 );
@@ -346,7 +346,6 @@ void sha256_process(sha256_context __far *ctx, const uint8_t __far data[64])
 	P( C, D, E, F, G, H, A, B, R(62), 0xBEF9A3F7 );
 	P( B, C, D, E, F, G, H, A, R(63), 0xC67178F2 );
 
-	state = ctx->state;
 	work = &A;
 	for (i = 0; i < 8; ++state, ++work, ++i)
 	{
@@ -501,7 +500,7 @@ void _sha256_finish_common(sha256_context __far *ctx, uint8_t __far *digest,
 
 	sha256_add(ctx, _sha_pad, padn);
 	sha256_add(ctx, msglen, 8);
-	
+
 	sha_copy_and_swap(digest, ctx->state, digest_length);
 }
 

--- a/Lib/Rabbit4000/tcpip/SSL/X509.LIB
+++ b/Lib/Rabbit4000/tcpip/SSL/X509.LIB
@@ -595,15 +595,15 @@ int _x509_s3_x509_str_compare(char __far * a, char __far * b);
 /*** EndHeader */
 _x509_debug
 int _x509_s3_x509_str_compare(char __far * a, char __far * b) {
-	if (!a &&
-	b)
-		return  -1;
-	if (a &&
-	!b)
-		return 1;
-	if (!a &&
-	!b)
+	if (!a && !b)
 		return 0;
+
+	if (!a)
+		return  -1;
+
+	if (!b)
+		return 1;
+
 	return _f_strcmp(a, b);
 }
 
@@ -615,16 +615,15 @@ _x509_debug
 int x509_name_compare(struct x509_name __far * a, struct x509_name __far * b) {
 	int res; 	// From "x509v3.c":100
 
-
-	if (!a &&
-	b)
-		return  -1;
-	if (a &&
-	!b)
-		return 1;
-	if (!a &&
-	!b)
+	if (!a && !b)
 		return 0;
+
+	if (!a)
+		return  -1;
+
+	if (!b)
+		return 1;
+
 	res = _x509_s3_x509_str_compare(a->cn, b->cn);
 	if (res)
 		return res;
@@ -643,10 +642,8 @@ int x509_name_compare(struct x509_name __far * a, struct x509_name __far * b) {
 	res = _x509_s3_x509_str_compare(a->ou, b->ou);
 	if (res)
 		return res;
-	res = _x509_s3_x509_str_compare(a->email, b->email);
-	if (res)
-		return res;
-	return 0;
+
+	return(_x509_s3_x509_str_compare(a->email, b->email));
 }
 
 /*** BeginHeader _x509_s3_x509_parse_algorithm_identifier */
@@ -860,71 +857,81 @@ void x509_name_string(struct x509_name __far * name, char __far * buf, size_t le
 _x509_debug
 void x509_name_string(struct x509_name __far * name, char __far * buf, size_t len) {
 	char __far * pos; 	// From "x509v3.c":400
-	char __far * end; 	// From "x509v3.c":400
 	int ret; 	// From "x509v3.c":401
+    int remaining;
 
-
-	if (len==0)
+	if (!len)
 		return /*void*/;
+
 	pos = buf;
-	end = buf+len;
+    remaining = len;
 	if (name->c) {
-		ret = snprintf(pos, (_x509_ptrdiff_t)(end-pos), "C=%ls, " , (char  __far * )(name->c));
+		ret = snprintf(pos, remaining , "C=%ls, " , (char  __far * )(name->c));
 		if (ret<0 ||
-		ret>=(_x509_ptrdiff_t)(end-pos))
+		ret>=remaining)
 			goto done;
 		pos += ret;
+		remaining -= ret;
 	}
 	if (name->st) {
-		ret =snprintf(pos, (_x509_ptrdiff_t)(end-pos), "ST=%ls, " , (char  __far * )(name->st));
+		ret =snprintf(pos, remaining, "ST=%ls, " , (char  __far * )(name->st));
 		if (ret<0 ||
-		ret>=(_x509_ptrdiff_t)(end-pos))
+		ret>=remaining)
 			goto done;
 		pos += ret;
+		remaining -= ret;
 	}
 	if (name->l) {
-		ret = snprintf(pos, (_x509_ptrdiff_t)(end-pos), "L=%ls, " , (char  __far * )(name->l));
+		ret = snprintf(pos, remaining, "L=%ls, " , (char  __far * )(name->l));
 		if (ret<0 ||
-		ret>=(_x509_ptrdiff_t)(end-pos))
+		ret>=remaining)
 			goto done;
 		pos += ret;
+		remaining -= ret;
 	}
 	if (name->o) {
-		ret = snprintf(pos, (_x509_ptrdiff_t)(end-pos), "O=%ls, " , (char  __far * )(name->o));
+		ret = snprintf(pos, remaining, "O=%ls, " , (char  __far * )(name->o));
 		if (ret<0 ||
-		ret>=(_x509_ptrdiff_t)(end-pos))
+		ret>=remaining)
 			goto done;
 		pos += ret;
+		remaining -= ret;
 	}
 	if (name->ou) {
-		ret = snprintf(pos, (_x509_ptrdiff_t)(end-pos), "OU=%ls, " , (char  __far * )(name->ou));
+		ret = snprintf(pos, remaining, "OU=%ls, " , (char  __far * )(name->ou));
 		if (ret<0 ||
-		ret>=(_x509_ptrdiff_t)(end-pos))
+		ret>=remaining)
 			goto done;
 		pos += ret;
+		remaining -= ret;
 	}
 	if (name->cn) {
-		ret = snprintf(pos, (_x509_ptrdiff_t)(end-pos), "CN=%ls, " , (char  __far * )(name->cn));
+		ret = snprintf(pos, remaining, "CN=%ls, " , (char  __far * )(name->cn));
 		if (ret<0 ||
-		ret>=(_x509_ptrdiff_t)(end-pos))
+		ret>=remaining)
 			goto done;
 		pos += ret;
+		remaining -= ret;
 	}
+#if 0
 	if (pos>buf+1 &&
 	pos[ -1]==' ' &&
 	pos[ -2]==',') {
 		*pos-- = '\0';
 		*pos-- = '\0';
 	}
+#else
+	if(len != remaining) { // At least 1 "x=y, " inserted so drop trailing ", "
+		pos -= 2;
+        *pos = '\0';
+    }
+#endif
 	if (name->email) {
-		ret = snprintf(pos, (_x509_ptrdiff_t)(end-pos), "/emailAddress=%ls" , (char  __far * )(name->email));
-		if (ret<0 ||
-		ret>=(_x509_ptrdiff_t)(end-pos))
-			goto done;
-		pos += ret;
+		ret = snprintf(pos, remaining, "/emailAddress=%ls" , (char  __far * )(name->email));
 	}
+
 	done:
-	end[ -1] = '\0';
+	buf[len-1] = '\0';
 }
 
 /*** BeginHeader _x509_s3_x509_parse_validity */
@@ -1414,7 +1421,7 @@ int _x509_s3_x509_nistAlgorithm_oid(struct asn1_oid __far * oid) {
    {
    	return (int) oid->oid[8];
    }
-   
+
    return -1;
 }
 
@@ -1587,7 +1594,7 @@ int x509_certificate_check_signature(struct x509_certificate __far * issuer,
 		_sys_free(data);
 		return  -1;
 	}
-	
+
 	sig_type = cert->signature.oid.oid[6];
 	digest_alg = NULL;
 	switch (_x509_s3_x509_nistAlgorithm_oid(&oid)) {
@@ -1612,7 +1619,7 @@ int x509_certificate_check_signature(struct x509_certificate __far * issuer,
 		}
 		goto skip_digest_oid;
 	}
-	
+
 	if (!_x509_s3_x509_digest_oid(&oid)) {
 		_X509_PRINTF((MSG_DEBUG, "X509: Unrecognized digestAlgorithm" ));
 		_sys_free(data);
@@ -1687,7 +1694,7 @@ int x509_certificate_check_signature(struct x509_certificate __far * issuer,
 		return  -1;
 	}
    _X509_HEXDUMP((MSG_MSGDUMP, "X509: Certificate hash" , hash, hash_len));
-	
+
 	if (hdr.length!=hash_len ||
 	_f_memcmp(hdr.payload, hash, hdr.length)!=0) {
 		_X509_PRINTF((MSG_INFO, "X509: Certificate Digest does not match " \
@@ -2110,7 +2117,7 @@ int x509_validate_hostname(const struct x509_certificate __far *cert,
 {
 	const char __far *cn, *cn_end, *hostname_end;
    int t;
-   
+
 	if (cert == NULL || cert->subject.cn == NULL || hostname == NULL)
    {
    	return -EINVAL;
@@ -2122,16 +2129,16 @@ int x509_validate_hostname(const struct x509_certificate __far *cert,
    cn = cert->subject.cn;
    cn_end = _f_strchr(cn, '\0') - 1;
    hostname_end = _f_strchr(hostname, '\0') - 1;
-      
+
    _X509_PRINTF((MSG_DEBUG, "X509: compare hostname '%ls' to CN '%ls'\n",
    	hostname, cn));
-   
+
    while (cn_end >= cn && hostname_end >= hostname && *cn_end == *hostname_end)
    {
    	--hostname_end;
       --cn_end;
    }
-   
+
    // cn_end and hostname_end point to characters that do not match, or
    // one or both of them point before the start of the string.
    if (hostname_end < hostname)
@@ -2175,7 +2182,7 @@ int x509_validate_hostname(const struct x509_certificate __far *cert,
       // here because *.example.com is NOT valid for foo.bar.example.com
       // fall through to failure case
    }
-   
+
    _X509_PRINTF((MSG_DEBUG, "\tINVALID\n"));
    return -NETERR_HOST_REFUSED;
 }
@@ -2212,7 +2219,7 @@ int _test_x509_validate_hostname(int verbose)
 	int i, result, failures = 0;
 
    if (verbose) printf("%s: running %u tests\n", __FUNCTION__, TEST_COUNT);
-   
+
    if (x509_validate_hostname(NULL, "foo") != -EINVAL)
    {
       ++failures;
@@ -2227,16 +2234,16 @@ int _test_x509_validate_hostname(int verbose)
       	++failures;
          if (verbose) printf("FAIL test %u: expected %d, got %d\n", i + 1,
          	test_case[i].expected_result, result);
-      } 
+      }
    }
-   
+
    if (failures)
    {
    	if (verbose)
       	printf("%s: FAILED %u/%u\n", __FUNCTION__, failures, TEST_COUNT);
    	return -1;
    }
-   
+
    if (verbose)
    	printf("%s: PASSED all %u tests\n", __FUNCTION__, TEST_COUNT);
 	return 0;


### PR DESCRIPTION
These changes help to reduce the code size when SSL support is enabled by around 1.5 to 2 KB. The overall functionality should be unchanged.
