### PR TITLE
Mem lib code size reduction

### DIFF
--- a/Lib/Rabbit4000/RabbitSys/mem.lib
+++ b/Lib/Rabbit4000/RabbitSys/mem.lib
@@ -93,6 +93,7 @@ void xalloc_init(_sys_mem_origin_t *orgtbl, uint16 orgtblsize) {
    auto int i;
    auto xbreak_t xsbreak;
    auto long available;
+   _sys_mem_origin_t *porgtbl;
 	// Ensure that the allocations are aligned on an even boundary.
 	#define XBREAK_T_ADJ ((sizeof(xbreak_t)-1|1)+1)
 
@@ -103,20 +104,21 @@ void xalloc_init(_sys_mem_origin_t *orgtbl, uint16 orgtblsize) {
    i = orgtblsize-1;
 
 	do {
+	  porgtbl = &orgtbl[i];
       // Note tmp is used below in root2xmem and is used to update
       // the next pointer.
-      if (orgtbl[i].type == RVARORG) {
+      if (porgtbl->type == RVARORG) {
       	continue;
       }
-      available = orgtbl[i].totalbytes - orgtbl[i].usedbytes - 2;
+      available = porgtbl->totalbytes - porgtbl->usedbytes - 2;
       if (XBREAK_T_ADJ >= available) {
       	continue;
       }
-      if (orgtbl[i].type == XVARORG) {
-         tmp = orgtbl[i].paddr - available;
+      if (porgtbl->type == XVARORG) {
+         tmp = porgtbl->paddr - available;
       }
       else {
-		   tmp = orgtbl[i].paddr + orgtbl[i].usedbytes;
+		   tmp = porgtbl->paddr + porgtbl->usedbytes;
       }
       if(tmp <= USER_XALLOC_START) {
          break;
@@ -125,12 +127,11 @@ void xalloc_init(_sys_mem_origin_t *orgtbl, uint16 orgtblsize) {
       xsbreak.sbreak = tmp + available;
       xsbreak.next = prev_xsbreak;
       prev_xsbreak = tmp;
-      xsbreak.flags = orgtbl[i].flags;
+      xsbreak.flags = porgtbl->flags;
       xsbreak.chksum = alloc_calc_chksum(&xsbreak, sizeof(xbreak_t));
       root2xmem(tmp, &xsbreak, sizeof(xbreak_t));
       prior_tmp = tmp;
    } while(--i);
-
    xubreak = prior_tmp;
 
 }


### PR DESCRIPTION
This code change reduces the size of the xalloc_init() function by about 60 bytes
