### PR TITLE
Small fix for swapped parameters in the bu_errmsg macro function

### DIFF
--- a/Lib/Rabbit4000/RemoteProgramUpdate/board_update.lib
+++ b/Lib/Rabbit4000/RemoteProgramUpdate/board_update.lib
@@ -155,8 +155,8 @@ END DESCRIPTION **********************************************************/
 #ifdef BOARD_UPDATE_VERBOSE
 	#define bu_errmsg(err, func) \
 		{ if (err) \
-			printf( "%s: error %d (%ls) calling %s at line %u\n", err, \
-				__FUNCTION__, strerror(err), func, __LINE__); }
+			printf( "%s: error %d (%ls) calling %s at line %u\n", __FUNCTION__, \
+				err, strerror(err), func, __LINE__); }
 #else
 	#define bu_errmsg(err, func)
 #endif


### PR DESCRIPTION
In bu_errmsg '__FUNCTION__' and 'err' were swapped giving semi-mangled output when called.