### PR TITLE
fixes typo in "_ip_delay2" which left off leading underscore

### DIFF
--- a/Lib/Rabbit4000/tcpip/net.lib
+++ b/Lib/Rabbit4000/tcpip/net.lib
@@ -7379,13 +7379,13 @@ int _ip_delay1( sock_type *s, int timeoutseconds,
    return( status );
 }
 
-/*** BeginHeader ip_delay2 */
-int ip_delay2( sock_type *s, int timeoutseconds, sockfunct_t fn,
+/*** BeginHeader _ip_delay2 */
+int _ip_delay2( sock_type *s, int timeoutseconds, sockfunct_t fn,
 	int *statusptr);
 /*** EndHeader */
 
 _net_nodebug
-int ip_delay2( sock_type *s, int timeoutseconds,
+int _ip_delay2( sock_type *s, int timeoutseconds,
 	sockfunct_t fn, int *statusptr)
 {
    auto int status;


### PR DESCRIPTION
caused compilation error when attempting to call sock_wait_closed

sock_wait_closed is a macro for 
```c
// net.lib line 1531
#define sock_wait_closed(s, seconds, fn, statusptr )\
    if (_ip_delay2( (sock_type*)s, seconds, fn, statusptr )) goto sock_err;
```