### PR TITLE
Further R6K EXP changes

### DIFF
--- a/Lib/Rabbit4000/BIOSLIB/CPUPARAM.LIB
+++ b/Lib/Rabbit4000/BIOSLIB/CPUPARAM.LIB
@@ -268,21 +268,21 @@ END DESCRIPTION ***************************************************************/
 extern int exp_ok;
 extern int exp_not_ok;
 #endif
-void setEXPCanonical(void);
+root void setEXPCanonical(void);
 /*** EndHeader */
 
 #if defined(INSTRUMENT_ALT_P)
 int exp_ok = 0;
 int exp_not_ok = 0;
 #endif
-__nodebug void setEXPCanonical(void)
+root __nodebug void setEXPCanonical(void)
 {
 #if _RAB6K
 	#asm
 	ipset	3		; nothing should interrupt this
 	; Test if proper state using RL1REG which effectively should swap jkhl and pw.
-	push	pw		; always preserve caller's view of PW
-	ld		bcde,0
+	ld jkhl', pw	; always preserve caller's view of PW
+    ld		bcde,0
 	ld		pw',bcde		; should be preserved at 0
 	ld		jkhl,1
 	rl1reg
@@ -304,7 +304,7 @@ __nodebug void setEXPCanonical(void)
 #else
 .skip:
 #endif
-	pop	pw
+	ld pw, jkhl'
 	ipres
 	#endasm
 #endif

--- a/Lib/Rabbit4000/BIOSLIB/CPUPARAM.LIB
+++ b/Lib/Rabbit4000/BIOSLIB/CPUPARAM.LIB
@@ -262,6 +262,8 @@ DESCRIPTION:	Work around following bug in Rabbit 6000:
 	generated due to context switching. This macro must be defined in the
 	project options as cpuparam.lib has its macros processed before main.
 
+    Trashes JKHL, JKHL', BCDE, PW' but does preserve PW.
+
 END DESCRIPTION ***************************************************************/
 /*** BeginHeader setEXPCanonical, exp_ok, exp_not_ok */
 #if defined(INSTRUMENT_ALT_P)

--- a/Lib/Rabbit4000/BIOSLIB/DKCORE.LIB
+++ b/Lib/Rabbit4000/BIOSLIB/DKCORE.LIB
@@ -374,12 +374,18 @@ dkSaveContext::
    push  py ; 9
    push  px ; 13
    push  pw ; 17
+#if _RAB6K
+   alts push  pz ; 21
+   alts push  py ; 25
+   alts push  px ; 29
+   alts push  pw ; 33
+#else
    exp
    push  pz ; 21
    push  py ; 25
    push  px ; 29
    push  pw ; 33
-   _EXP_IF_RAB6K ; Maintain the p/'p order if possible
+#endif
 	push	iy ; 35
 	push	ix ; 37
 	push	jkhl ; 41
@@ -1437,12 +1443,18 @@ dkRestoreContext::
 	pop	jkhl
 	pop	ix
 	pop	iy
-   _EXP_IF_RAB6K ; Maintain the p/'p order if possible
+#if _RAB6K
+   altd pop   pw
+   altd pop   px
+   altd pop   py
+   altd pop   pz
+#else
    pop   pw
    pop   px
    pop   py
    pop   pz
    exp      ; Exchange the 32-bit pointer registers
+#endif
    pop   pw
    pop   px
    pop   py

--- a/Lib/Rabbit4000/Crypto/SHA1.LIB
+++ b/Lib/Rabbit4000/Crypto/SHA1.LIB
@@ -227,7 +227,7 @@ __root void sha_xor(void);
 	// so it ends up in PZ'.  Then JKHL is loaded with Z' so it gets fed into
 	// PW.
 	#define SHA_CYCLE \
-		ipset 3 $ exp $ ld py,jkhl $ ld jkhl,pz $ exp $ ipres $ RR8REG
+		altd ld py,jkhl $ alts ld jkhl,pz $ RR8REG
 #else
 	#define SHA_CYCLE \
 	   ld    pz,py $ \
@@ -713,6 +713,7 @@ void sha_transform(sha_state __far*_state)
    ; Now move message block.  We need to reverse its overall
    ; order so that X0 is at highest stack address.  Not only that,
    ; but the endianness is also swapped.
+    align odd
 	SHA_RMOVE(0)
 	SHA_RMOVE(1)
 	SHA_RMOVE(2)

--- a/Lib/Rabbit4000/STDVDRIVER.LIB
+++ b/Lib/Rabbit4000/STDVDRIVER.LIB
@@ -162,6 +162,7 @@ ioi	ld		(WDTCR), a				; now restart the secondary watch dog timer
 ; completion of the ISR to not be delayed past the next periodic interrupt by
 ; other interrupts.
 ;
+   align odd
 periodic_isr::
 		push	af							; 10  save registers used during this ISR
 		push	ip							; 9
@@ -411,7 +412,26 @@ ioi	ld		(_ENET_ACT_D), a
 		ex		af, af'
 		push	af
 		exx
+#if _RAB6K
+        align even
+		push	jkhl
+		push	bcde
+		push	iy
+		alts push	pw
+		alts push	px
+		alts push	py
+		alts push	pz
+		lcall	bios_intexit
+		altd pop	pz
+		altd pop	py
+		altd pop	px
+		altd pop	pw
+		pop	iy
+		pop	bcde
+		pop	jkhl
+#else
 		exp
+        align even
 		push	jkhl
 		push	bcde
 		push	iy
@@ -430,7 +450,9 @@ ioi	ld		(_ENET_ACT_D), a
 		pop	bcde
 		pop	jkhl
 		exp
+#endif
 		exx
+        align even
 		pop	af
 		ex		af, af'
 		pop	pz

--- a/Lib/Rabbit4000/STDVDRIVER.LIB
+++ b/Lib/Rabbit4000/STDVDRIVER.LIB
@@ -162,7 +162,9 @@ ioi	ld		(WDTCR), a				; now restart the secondary watch dog timer
 ; completion of the ISR to not be delayed past the next periodic interrupt by
 ; other interrupts.
 ;
-   align odd
+   align odd  ; This makes several long strings of 2 byte instructions
+              ; in the ISR align on even boundaries which improves performance
+              ; on 16 bit memory.
 periodic_isr::
 		push	af							; 10  save registers used during this ISR
 		push	ip							; 9
@@ -413,7 +415,7 @@ ioi	ld		(_ENET_ACT_D), a
 		push	af
 		exx
 #if _RAB6K
-        align even
+        align even   ; Makes most of stacking and unstacking even aligned
 		push	jkhl
 		push	bcde
 		push	iy


### PR DESCRIPTION
Removed some of the EXP instructions for R6K as they could still lead to an imbalance in the EXP count count if interrupts are preempted.